### PR TITLE
Update default chart color and add visualization utilities

### DIFF
--- a/apps/portal/src/components/displayItems/HighlightedSingleValueVisualizer/components/HighlightedValueDisplay.tsx
+++ b/apps/portal/src/components/displayItems/HighlightedSingleValueVisualizer/components/HighlightedValueDisplay.tsx
@@ -1,5 +1,7 @@
+import { VisualizationConfig } from "@packages/shared/schemas";
 import { dhis2HttpClient } from "@/utils/api/dhis2";
 import { findIndex, head } from "lodash";
+import { getPeriods } from "@packages/shared/utils";
 import { NumberFormatter, Title } from "@mantine/core";
 import { getAppearanceConfig } from "@/utils/config/appConfig";
 

--- a/apps/portal/src/components/displayItems/HighlightedSingleValueVisualizer/components/HighlightedValueDisplay.tsx
+++ b/apps/portal/src/components/displayItems/HighlightedSingleValueVisualizer/components/HighlightedValueDisplay.tsx
@@ -1,7 +1,5 @@
-import { VisualizationConfig } from "@packages/shared/schemas";
 import { dhis2HttpClient } from "@/utils/api/dhis2";
 import { findIndex, head } from "lodash";
-import { getPeriods } from "@packages/shared/utils";
 import { NumberFormatter, Title } from "@mantine/core";
 import { getAppearanceConfig } from "@/utils/config/appConfig";
 
@@ -40,7 +38,7 @@ export async function HighlightedValueDisplay({
 }) {
 	const data = await getVisualizationData(visualizationConfig);
 	const appearanceConfig = await getAppearanceConfig();
-	const color = appearanceConfig?.appearanceConfig.colors.chartColors[1];
+	const color = appearanceConfig?.appearanceConfig.colors.chartColors[0];
 
 	return (
 		<Title style={{ color }} className={`!text-5xl`} order={1}>


### PR DESCRIPTION
### Description of changes

- Modified the default chart color logic to use the first option in `chartColors` array, aligning with default appearance settings and design preferences.

Fixes #163